### PR TITLE
Fix: ErrorException in EventSendResponse due to  Undefined array key "message" (add missing null coalesce operator)

### DIFF
--- a/src/Requests/Events/EventSendRequest.php
+++ b/src/Requests/Events/EventSendRequest.php
@@ -32,7 +32,7 @@ class EventSendRequest extends Request implements HasBody
 
         return new EventSendResponse(
             success: $data['success'],
-            message: $data['message']
+            message: $data['message'] ?? null
         );
     }
 


### PR DESCRIPTION
Adds a null coalesce here, as the "message" can be null.

```php
return new EventSendResponse(
    success: $data['success'],
    message: $data['message'] ?? null // <-- here
);
```