### PR TITLE
chore: upgrade phpstan, rector to 2.0 and bump other dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
     "require": {
         "php": "^8.1",
         "saloonphp/saloon": "^3.7",
-        "thecodingmachine/safe": "^2.5"
+        "thecodingmachine/safe": "^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42",
         "laravel/pint": "^1.14",
         "pestphp/pest": "^2.34",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "rector/rector": "^1.0",
-        "spaze/phpstan-disallowed-calls": "^3.1",
-        "thecodingmachine/phpstan-safe-rule": "^1.2"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "rector/rector": "^2.0",
+        "spaze/phpstan-disallowed-calls": "^4.0",
+        "thecodingmachine/phpstan-safe-rule": "^1.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,11 @@ includes:
 
 parameters:
   checkBenevolentUnionTypes: true
-  checkMissingIterableValueType: false
   level: max
+
+  ignoreErrors:
+    -
+        identifier: missingType.iterableValue
 
   paths:
     - src

--- a/rector.php
+++ b/rector.php
@@ -2,11 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -20,11 +17,6 @@ return RectorConfig::configure()
         typeDeclarations: true,
         earlyReturn: true
     )
-    ->withRules([
-        AddVoidReturnTypeWhereNoReturnRector::class,
-        InlineConstructorDefaultToPropertyRector::class,
-    ])
     ->withSkip([
-        CallableThisArrayToAnonymousFunctionRector::class,
         ClosureToArrowFunctionRector::class,
     ]);

--- a/src/DataTransferObjects/Contact.php
+++ b/src/DataTransferObjects/Contact.php
@@ -6,6 +6,9 @@ namespace PlutoLinks\Loops\DataTransferObjects;
 
 class Contact
 {
+    /**
+     * @var list<string>
+     */
     public const DEFAULT_PROPERTIES = [
         'email',
         'firstName',

--- a/src/DataTransferObjects/CustomField.php
+++ b/src/DataTransferObjects/CustomField.php
@@ -16,6 +16,9 @@ class CustomField
     ) {
     }
 
+    /**
+     * @param array{key: string, label: string, type: 'boolean'|'date'|'number'|'string'} $attributes
+     */
     public static function from(array $attributes): CustomField
     {
         return new CustomField(

--- a/src/Requests/Contacts/ContactCustomFieldsRequest.php
+++ b/src/Requests/Contacts/ContactCustomFieldsRequest.php
@@ -15,7 +15,7 @@ class ContactCustomFieldsRequest extends Request
 
     public function createDtoFromResponse(Response $response): array
     {
-        /** @var array<int, array{key: string, label: string, type: string}> $data */
+        /** @var array<int, array{key: string, label: string, type: 'boolean'|'date'|'number'|'string'}> $data */
         $data = $response->json();
 
         return array_map(fn (array $customField): CustomField => CustomField::from($customField), $data);


### PR DESCRIPTION
Wanted to upgrade my project to 8.4, which is currently not supported by this package because of the `thecodingmachine/safe` dependency at v2.5.

Figured I'd upgrade the rest while I'm at it.
 
Had to remove some deprecated Rector and PHPStan rules and add some docblocks to stay at level max for PHPStan.